### PR TITLE
FIXED: parse 'deriving' with class list

### DIFF
--- a/Language/Haskell/Exts/QQ.hs
+++ b/Language/Haskell/Exts/QQ.hs
@@ -83,6 +83,7 @@ qualify :: Name -> Name
 -- all else is a datatype defined in Syntax module of haskell-src-exts.
 qualify n | ":" <- nameBase n = '(:)
           | "[]" <- nameBase n = '[]
+          | "(,)" <- nameBase n = '(,)
           | "Nothing" <- nameBase n = 'Nothing
           | "Just" <- nameBase n = 'Just
           | "SrcLoc" <- nameBase n = 'Hs.SrcLoc


### PR DESCRIPTION
> 'deriving' clauses failed if the type class list included more than
> one type class, because the tuple constructor (,) wasn't kept
> unqualified.  This fix passes the (,) constructor through
> unqualified.
> 
> In short, the following now works:
> 
> ```
> [dec| newtype H = H { unH :: String } deriving (Eq, Show) |]
> [dec| data X = Y | Z deriving (Eq, Show) |]
> ```

What doesn't work yet is this:

```
[dec| newtype H = H { unH :: (String, Integer) } deriving (Eq, Show) |]
```

I'll open a bug, because I haven't figured out yet how to fix that one (error is similar to tuple above, but complains about `Language.Haskell.Exts.Syntax.Boxed`, which actually exists).
