### PR TITLE
filter DisableExtension{} from knownExtensions, fixes #8

### DIFF
--- a/Language/Haskell/Exts/QQ.hs
+++ b/Language/Haskell/Exts/QQ.hs
@@ -31,7 +31,8 @@ import Data.Generics
 import Data.List (intercalate, isPrefixOf, isSuffixOf)
 
 allExtensions :: Hs.ParseMode
-allExtensions = Hs.defaultParseMode{Hs.extensions = Hs.knownExtensions}
+allExtensions = Hs.defaultParseMode{Hs.extensions = known}
+  where known = [ext | ext@Hs.EnableExtension{} <- Hs.knownExtensions]
 
 -- | A quasiquoter for expressions. All Haskell extensions known by
 -- haskell-src-exts are activated by default.


### PR DESCRIPTION
See #8 for details.

the point is that 'knownExtensions' contains all extensions twice, once enabled and once disabled; in order to enable all of them, one has to drop the disabled ones.
